### PR TITLE
test: update EmailModal title assertions

### DIFF
--- a/src/__tests__/components/EmailModal.test.tsx
+++ b/src/__tests__/components/EmailModal.test.tsx
@@ -59,10 +59,10 @@ describe('EmailModal', () => {
 
   it('renders when open', () => {
     render(<EmailModal {...defaultProps} />)
-    
+
     expect(screen.getByRole('dialog')).toBeInTheDocument()
-    expect(screen.getByText('Email Coupons')).toBeInTheDocument()
-    expect(screen.getByText('Store #7046 • 2 coupons available')).toBeInTheDocument()
+    expect(screen.getByText('Email Coupons - Store #7046')).toBeInTheDocument()
+    expect(screen.getByText('2 coupons available')).toBeInTheDocument()
   })
 
   it('does not render when closed', () => {


### PR DESCRIPTION
## Summary
- test email modal heading for specific store and coupon availability separately

## Testing
- `npm test` (fails: Missing script "test")
- `npx vitest run` (fails: 403 Forbidden fetching vitest)


------
https://chatgpt.com/codex/tasks/task_e_688d2ef2ef2883209ba287a96fc0135e