### PR TITLE
chore: clarify test script placeholder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ npm install
 # Run development server
 npm run dev
 
-# Run tests
+# Run tests (currently none defined)
 npm test
 
 # Run linting

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ npm run dev
 - `npm run build` - Build for production
 - `npm run preview` - Preview production build
 - `npm run lint` - Run ESLint
-- `npm test` - Run tests
+- `npm test` - Placeholder script (no tests defined)
 
 ## 🌟 Key Features
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "echo \"No tests specified\"",
     "preview": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- note that `npm test` is a placeholder rather than a working test suite
- stub `test` script in package.json to echo a helpful message
- document absence of tests in contributing guide

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d2efd58d88320be38b17986ffaed3