### PR TITLE
fix: initialize refs in useDebounce

### DIFF
--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -36,8 +36,12 @@ export function useDebouncedCallback<T extends (...args: unknown[]) => unknown>(
 ): T {
   const callbackRef = useRef(callback)
   const delayRef = useRef(delay)
-  const timeoutRef = useRef<ReturnType<typeof setTimeout>>()
-  const debouncedRef = useRef<T & { cancel: () => void }>()
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  )
+  const debouncedRef = useRef<(T & { cancel: () => void }) | undefined>(
+    undefined
+  )
 
   if (!debouncedRef.current) {
     debouncedRef.current = ((...args: Parameters<T>) => {


### PR DESCRIPTION
## Summary
- ensure useDebouncedCallback refs default to `undefined`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d320dd9b883209b7df962f457d102